### PR TITLE
fix: only show data from current posyandu

### DIFF
--- a/module/home/model/home_model.go
+++ b/module/home/model/home_model.go
@@ -72,7 +72,7 @@ type BidanHomeResponse struct {
 }
 
 type HomeResponse struct {
-	User             HomeUserResponse               `json:"user"`
+	Remaja           HomeRemajaResponse             `json:"remaja"`
 	JadwalPosyandu   []HomeJadwalPosyanduResponse   `json:"jadwal_posyandu"`
 	JadwalPenyuluhan []HomeJadwalPenyuluhanResponse `json:"jadwal_penyuluhan"`
 }

--- a/module/home/service/home_service_impl.go
+++ b/module/home/service/home_service_impl.go
@@ -53,7 +53,7 @@ func (service *homeServiceImpl) GetBidan(id int) (model.BidanHomeResponse, error
 		})
 	}
 
-	pemeriksaan, err := service.pemeriksaanRepo.FindAll()
+	pemeriksaan, err := service.pemeriksaanRepo.FindAllByPosyanduID(posyandu.ID)
 	exception.PanicIfNeeded(err)
 
 	pemeriksaanResponse := make([]model.HomePemeriksaanResponse, len(pemeriksaan))

--- a/module/home/service/home_service_impl.go
+++ b/module/home/service/home_service_impl.go
@@ -112,7 +112,7 @@ func (service *homeServiceImpl) GetBidan(id int) (model.BidanHomeResponse, error
 		}
 	}
 
-	jadwalPosyandu, err := service.jadwalPosyanduRepo.FindAll()
+	jadwalPosyandu, err := service.jadwalPosyanduRepo.FindByPosyanduID(posyandu.ID)
 	exception.PanicIfNeeded(err)
 
 	jadwalPosyanduResponse := make([]model.HomeJadwalPosyanduResponse, len(jadwalPosyandu))
@@ -137,7 +137,7 @@ func (service *homeServiceImpl) GetBidan(id int) (model.BidanHomeResponse, error
 		}
 	}
 
-	jadwalPenyuluhan, err := service.jadwalPenyluhanRepo.FindAll()
+	jadwalPenyuluhan, err := service.jadwalPenyluhanRepo.FindByPosyanduID(posyandu.ID)
 	exception.PanicIfNeeded(err)
 
 	jadwalPenyuluhanResponse := make([]model.HomeJadwalPenyuluhanResponse, len(jadwalPenyuluhan))
@@ -200,7 +200,14 @@ func (service *homeServiceImpl) Get(id int) (model.HomeResponse, error) {
 		})
 	}
 
-	jadwalPosyandu, err := service.jadwalPosyanduRepo.FindAll()
+	remaja, err := service.remajaRepo.FindByUserID(user.ID)
+	if err != nil {
+		panic(exception.NotFoundError{
+			Message: "User is not remaja",
+		})
+	}
+
+	jadwalPosyandu, err := service.jadwalPosyanduRepo.FindByPosyanduID(remaja.PosyanduID)
 	exception.PanicIfNeeded(err)
 
 	jadwalPosyanduResponse := make([]model.HomeJadwalPosyanduResponse, len(jadwalPosyandu))
@@ -225,7 +232,7 @@ func (service *homeServiceImpl) Get(id int) (model.HomeResponse, error) {
 		}
 	}
 
-	jadwalPenyuluhan, err := service.jadwalPenyluhanRepo.FindAll()
+	jadwalPenyuluhan, err := service.jadwalPenyluhanRepo.FindByPosyanduID(remaja.PosyanduID)
 	exception.PanicIfNeeded(err)
 
 	jadwalPenyuluhanResponse := make([]model.HomeJadwalPenyuluhanResponse, len(jadwalPenyuluhan))
@@ -254,12 +261,24 @@ func (service *homeServiceImpl) Get(id int) (model.HomeResponse, error) {
 	}
 
 	response := model.HomeResponse{
-		User: model.HomeUserResponse{
-			ID:           user.ID,
-			Nama:         user.Nama,
-			NIK:          user.NIK,
-			TanggalLahir: user.TanggalLahir.Format("2006-01-02"),
-			Foto:         user.Foto,
+		Remaja: model.HomeRemajaResponse{
+			ID: remaja.ID,
+			Posyandu: model.HomePosyanduResponse{
+				ID:     remaja.PosyanduID,
+				Nama:   remaja.Posyandu.Nama,
+				Alamat: remaja.Posyandu.Alamat,
+				Foto:   remaja.Posyandu.Foto,
+			},
+			User: model.HomeUserResponse{
+				ID:           user.ID,
+				Nama:         user.Nama,
+				NIK:          user.NIK,
+				TanggalLahir: user.TanggalLahir.Format("2006-01-02"),
+				Foto:         user.Foto,
+			},
+			NamaAyah: remaja.NamaAyah,
+			NamaIbu:  remaja.NamaIbu,
+			IsKader:  remaja.IsKader,
 		},
 		JadwalPosyandu:   jadwalPosyanduResponse,
 		JadwalPenyuluhan: jadwalPenyuluhanResponse,

--- a/module/pemeriksaan/repository/pemeriksaan_repository.go
+++ b/module/pemeriksaan/repository/pemeriksaan_repository.go
@@ -6,6 +6,7 @@ type PemeriksaanRepository interface {
 	Insert(pemeriksaan *entity.Pemeriksaan) error
 	FindAll() ([]entity.Pemeriksaan, error)
 	FindAllByRemajaID(id int) ([]entity.Pemeriksaan, error)
+	FindAllByPosyanduID(id int) ([]entity.Pemeriksaan, error)
 	FindByID(id int) (entity.Pemeriksaan, error)
 	FindLastByRemajaID(id int) (entity.Pemeriksaan, error)
 	Save(pemeriksaan *entity.Pemeriksaan) error

--- a/module/pemeriksaan/repository/pemeriksaan_repository_impl.go
+++ b/module/pemeriksaan/repository/pemeriksaan_repository_impl.go
@@ -27,6 +27,13 @@ func (repository *pemeriksaanRepositoryImpl) FindAllByRemajaID(id int) ([]entity
 	return pemeriksaan, err
 }
 
+func (repository *pemeriksaanRepositoryImpl) FindAllByPosyanduID(id int) ([]entity.Pemeriksaan, error) {
+	var pemeriksaan []entity.Pemeriksaan
+	err := repository.DB.Find(&pemeriksaan, "posyandu_id = ?", id).Error
+
+	return pemeriksaan, err
+}
+
 func (repository *pemeriksaanRepositoryImpl) FindByID(id int) (entity.Pemeriksaan, error) {
 	var pemeriksaan entity.Pemeriksaan
 	err := repository.DB.Take(&pemeriksaan, id).Error


### PR DESCRIPTION
### Fix

Resolve #32 

### Reason

Showing data from all posyandu instead of only current posyandu

From
```go
jadwalPosyandu, err := service.jadwalPosyanduRepo.FindAll()
```

to
```go
jadwalPosyandu, err := service.jadwalPosyanduRepo.FindByPosyanduID(posyandu.ID)
```