### PR TITLE
fix: format time with correct timezone

### DIFF
--- a/module/home/model/home_model.go
+++ b/module/home/model/home_model.go
@@ -72,7 +72,7 @@ type BidanHomeResponse struct {
 }
 
 type HomeResponse struct {
-	User             HomeUserResponse               `json:"user"`
+	Remaja           HomeRemajaResponse             `json:"remaja"`
 	JadwalPosyandu   []HomeJadwalPosyanduResponse   `json:"jadwal_posyandu"`
 	JadwalPenyuluhan []HomeJadwalPenyuluhanResponse `json:"jadwal_penyuluhan"`
 }

--- a/module/home/service/home_service_impl.go
+++ b/module/home/service/home_service_impl.go
@@ -53,7 +53,7 @@ func (service *homeServiceImpl) GetBidan(id int) (model.BidanHomeResponse, error
 		})
 	}
 
-	pemeriksaan, err := service.pemeriksaanRepo.FindAll()
+	pemeriksaan, err := service.pemeriksaanRepo.FindAllByPosyanduID(posyandu.ID)
 	exception.PanicIfNeeded(err)
 
 	pemeriksaanResponse := make([]model.HomePemeriksaanResponse, len(pemeriksaan))

--- a/module/home/service/home_service_impl.go
+++ b/module/home/service/home_service_impl.go
@@ -112,7 +112,7 @@ func (service *homeServiceImpl) GetBidan(id int) (model.BidanHomeResponse, error
 		}
 	}
 
-	jadwalPosyandu, err := service.jadwalPosyanduRepo.FindAll()
+	jadwalPosyandu, err := service.jadwalPosyanduRepo.FindByPosyanduID(posyandu.ID)
 	exception.PanicIfNeeded(err)
 
 	jadwalPosyanduResponse := make([]model.HomeJadwalPosyanduResponse, len(jadwalPosyandu))
@@ -137,7 +137,7 @@ func (service *homeServiceImpl) GetBidan(id int) (model.BidanHomeResponse, error
 		}
 	}
 
-	jadwalPenyuluhan, err := service.jadwalPenyluhanRepo.FindAll()
+	jadwalPenyuluhan, err := service.jadwalPenyluhanRepo.FindByPosyanduID(posyandu.ID)
 	exception.PanicIfNeeded(err)
 
 	jadwalPenyuluhanResponse := make([]model.HomeJadwalPenyuluhanResponse, len(jadwalPenyuluhan))
@@ -200,7 +200,14 @@ func (service *homeServiceImpl) Get(id int) (model.HomeResponse, error) {
 		})
 	}
 
-	jadwalPosyandu, err := service.jadwalPosyanduRepo.FindAll()
+	remaja, err := service.remajaRepo.FindByUserID(user.ID)
+	if err != nil {
+		panic(exception.NotFoundError{
+			Message: "User is not remaja",
+		})
+	}
+
+	jadwalPosyandu, err := service.jadwalPosyanduRepo.FindByPosyanduID(remaja.PosyanduID)
 	exception.PanicIfNeeded(err)
 
 	jadwalPosyanduResponse := make([]model.HomeJadwalPosyanduResponse, len(jadwalPosyandu))
@@ -225,7 +232,7 @@ func (service *homeServiceImpl) Get(id int) (model.HomeResponse, error) {
 		}
 	}
 
-	jadwalPenyuluhan, err := service.jadwalPenyluhanRepo.FindAll()
+	jadwalPenyuluhan, err := service.jadwalPenyluhanRepo.FindByPosyanduID(remaja.PosyanduID)
 	exception.PanicIfNeeded(err)
 
 	jadwalPenyuluhanResponse := make([]model.HomeJadwalPenyuluhanResponse, len(jadwalPenyuluhan))
@@ -254,12 +261,24 @@ func (service *homeServiceImpl) Get(id int) (model.HomeResponse, error) {
 	}
 
 	response := model.HomeResponse{
-		User: model.HomeUserResponse{
-			ID:           user.ID,
-			Nama:         user.Nama,
-			NIK:          user.NIK,
-			TanggalLahir: user.TanggalLahir.Format("2006-01-02"),
-			Foto:         user.Foto,
+		Remaja: model.HomeRemajaResponse{
+			ID: remaja.ID,
+			Posyandu: model.HomePosyanduResponse{
+				ID:     remaja.PosyanduID,
+				Nama:   remaja.Posyandu.Nama,
+				Alamat: remaja.Posyandu.Alamat,
+				Foto:   remaja.Posyandu.Foto,
+			},
+			User: model.HomeUserResponse{
+				ID:           user.ID,
+				Nama:         user.Nama,
+				NIK:          user.NIK,
+				TanggalLahir: user.TanggalLahir.Format("2006-01-02"),
+				Foto:         user.Foto,
+			},
+			NamaAyah: remaja.NamaAyah,
+			NamaIbu:  remaja.NamaIbu,
+			IsKader:  remaja.IsKader,
 		},
 		JadwalPosyandu:   jadwalPosyanduResponse,
 		JadwalPenyuluhan: jadwalPenyuluhanResponse,

--- a/module/home/service/home_service_impl.go
+++ b/module/home/service/home_service_impl.go
@@ -11,6 +11,7 @@ import (
 	posyanduRepository "github.com/itsLeonB/posyandu-api/module/posyandu/repository"
 	remajaRepository "github.com/itsLeonB/posyandu-api/module/remaja/repository"
 	userRepository "github.com/itsLeonB/posyandu-api/module/user/repository"
+	"time"
 )
 
 type homeServiceImpl struct {
@@ -107,7 +108,7 @@ func (service *homeServiceImpl) GetBidan(id int) (model.BidanHomeResponse, error
 			TingkatGlukosa:  pemeriksaan.TingkatGlukosa,
 			KadarHemoglobin: pemeriksaan.KadarHemoglobin,
 			PemberianFe:     pemeriksaan.PemberianFe,
-			WaktuPengukuran: pemeriksaan.WaktuPengukuran.Format("2006-01-02 15:04:05"),
+			WaktuPengukuran: pemeriksaan.WaktuPengukuran.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
 			KondisiUmum:     pemeriksaan.KondisiUmum,
 		}
 	}
@@ -132,8 +133,8 @@ func (service *homeServiceImpl) GetBidan(id int) (model.BidanHomeResponse, error
 				Alamat: posyandu.Alamat,
 				Foto:   posyandu.Foto,
 			},
-			WaktuMulai:   jadwalPosyandu.WaktuMulai.Format("2006-01-02 15:04:05"),
-			WaktuSelesai: jadwalPosyandu.WaktuSelesai.Format("2006-01-02 15:04:05"),
+			WaktuMulai:   jadwalPosyandu.WaktuMulai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
+			WaktuSelesai: jadwalPosyandu.WaktuSelesai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
 		}
 	}
 
@@ -157,8 +158,8 @@ func (service *homeServiceImpl) GetBidan(id int) (model.BidanHomeResponse, error
 				Alamat: posyandu.Alamat,
 				Foto:   posyandu.Foto,
 			},
-			WaktuMulai:   jadwalPenyuluhan.WaktuMulai.Format("2006-01-02 15:04:05"),
-			WaktuSelesai: jadwalPenyuluhan.WaktuSelesai.Format("2006-01-02 15:04:05"),
+			WaktuMulai:   jadwalPenyuluhan.WaktuMulai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
+			WaktuSelesai: jadwalPenyuluhan.WaktuSelesai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
 			Title:        jadwalPenyuluhan.Title,
 			Materi:       jadwalPenyuluhan.Materi,
 			Feedback:     jadwalPenyuluhan.Feedback,
@@ -227,8 +228,8 @@ func (service *homeServiceImpl) Get(id int) (model.HomeResponse, error) {
 				Alamat: posyandu.Alamat,
 				Foto:   posyandu.Foto,
 			},
-			WaktuMulai:   jadwalPosyandu.WaktuMulai.Format("2006-01-02 15:04:05"),
-			WaktuSelesai: jadwalPosyandu.WaktuSelesai.Format("2006-01-02 15:04:05"),
+			WaktuMulai:   jadwalPosyandu.WaktuMulai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
+			WaktuSelesai: jadwalPosyandu.WaktuSelesai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
 		}
 	}
 
@@ -252,8 +253,8 @@ func (service *homeServiceImpl) Get(id int) (model.HomeResponse, error) {
 				Alamat: posyandu.Alamat,
 				Foto:   posyandu.Foto,
 			},
-			WaktuMulai:   jadwalPenyuluhan.WaktuMulai.Format("2006-01-02 15:04:05"),
-			WaktuSelesai: jadwalPenyuluhan.WaktuSelesai.Format("2006-01-02 15:04:05"),
+			WaktuMulai:   jadwalPenyuluhan.WaktuMulai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
+			WaktuSelesai: jadwalPenyuluhan.WaktuSelesai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
 			Title:        jadwalPenyuluhan.Title,
 			Materi:       jadwalPenyuluhan.Materi,
 			Feedback:     jadwalPenyuluhan.Feedback,

--- a/module/jadwal-penyuluhan/service/jadwal_penyuluhan_service_impl.go
+++ b/module/jadwal-penyuluhan/service/jadwal_penyuluhan_service_impl.go
@@ -7,6 +7,7 @@ import (
 	jadwalPenyuluhanRepository "github.com/itsLeonB/posyandu-api/module/jadwal-penyuluhan/repository"
 	"github.com/itsLeonB/posyandu-api/module/jadwal-penyuluhan/validation"
 	posyanduRepository "github.com/itsLeonB/posyandu-api/module/posyandu/repository"
+	"time"
 )
 
 type jadwalPenyuluhanServiceImpl struct {
@@ -80,8 +81,8 @@ func (service *jadwalPenyuluhanServiceImpl) GetAll() ([]model.JadwalPenyuluhanRe
 				Alamat: posyandu.Alamat,
 				Foto:   posyandu.Foto,
 			},
-			WaktuMulai:   jadwalPenyuluhan.WaktuMulai.Format("2006-01-02 15:04:05"),
-			WaktuSelesai: jadwalPenyuluhan.WaktuSelesai.Format("2006-01-02 15:04:05"),
+			WaktuMulai:   jadwalPenyuluhan.WaktuMulai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
+			WaktuSelesai: jadwalPenyuluhan.WaktuSelesai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
 			Title:        jadwalPenyuluhan.Title,
 			Materi:       jadwalPenyuluhan.Materi,
 			Feedback:     jadwalPenyuluhan.Feedback,
@@ -112,8 +113,8 @@ func (service *jadwalPenyuluhanServiceImpl) GetByPosyanduID(id int) ([]model.Jad
 				Alamat: posyandu.Alamat,
 				Foto:   posyandu.Foto,
 			},
-			WaktuMulai:   jadwalPenyuluhan.WaktuMulai.Format("2006-01-02 15:04:05"),
-			WaktuSelesai: jadwalPenyuluhan.WaktuSelesai.Format("2006-01-02 15:04:05"),
+			WaktuMulai:   jadwalPenyuluhan.WaktuMulai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
+			WaktuSelesai: jadwalPenyuluhan.WaktuSelesai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
 			Title:        jadwalPenyuluhan.Title,
 			Materi:       jadwalPenyuluhan.Materi,
 			Feedback:     jadwalPenyuluhan.Feedback,
@@ -146,8 +147,8 @@ func (service *jadwalPenyuluhanServiceImpl) GetByID(id int) (model.JadwalPenyulu
 			Alamat: posyandu.Alamat,
 			Foto:   posyandu.Foto,
 		},
-		WaktuMulai:   jadwalPenyuluhan.WaktuMulai.Format("2006-01-02 15:04:05"),
-		WaktuSelesai: jadwalPenyuluhan.WaktuSelesai.Format("2006-01-02 15:04:05"),
+		WaktuMulai:   jadwalPenyuluhan.WaktuMulai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
+		WaktuSelesai: jadwalPenyuluhan.WaktuSelesai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
 		Title:        jadwalPenyuluhan.Title,
 		Materi:       jadwalPenyuluhan.Materi,
 		Feedback:     jadwalPenyuluhan.Feedback,
@@ -198,8 +199,8 @@ func (service *jadwalPenyuluhanServiceImpl) Update(id int, request *model.Jadwal
 			Alamat: posyandu.Alamat,
 			Foto:   posyandu.Foto,
 		},
-		WaktuMulai:   jadwalPenyuluhan.WaktuMulai.Format("2006-01-02 15:04:05"),
-		WaktuSelesai: jadwalPenyuluhan.WaktuSelesai.Format("2006-01-02 15:04:05"),
+		WaktuMulai:   jadwalPenyuluhan.WaktuMulai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
+		WaktuSelesai: jadwalPenyuluhan.WaktuSelesai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
 		Title:        jadwalPenyuluhan.Title,
 		Materi:       jadwalPenyuluhan.Materi,
 		Feedback:     jadwalPenyuluhan.Feedback,

--- a/module/jadwal-posyandu/service/jadwal_posyandu_service_impl.go
+++ b/module/jadwal-posyandu/service/jadwal_posyandu_service_impl.go
@@ -7,6 +7,7 @@ import (
 	jadwalPosyanduRepository "github.com/itsLeonB/posyandu-api/module/jadwal-posyandu/repository"
 	"github.com/itsLeonB/posyandu-api/module/jadwal-posyandu/validation"
 	posyanduRepository "github.com/itsLeonB/posyandu-api/module/posyandu/repository"
+	"time"
 )
 
 type jadwalPosyanduServiceImpl struct {
@@ -74,8 +75,8 @@ func (service *jadwalPosyanduServiceImpl) GetAll() ([]model.JadwalPosyanduRespon
 				Alamat: posyandu.Alamat,
 				Foto:   posyandu.Foto,
 			},
-			WaktuMulai:   jadwalPosyandu.WaktuMulai.Format("2006-01-02 15:04:05"),
-			WaktuSelesai: jadwalPosyandu.WaktuSelesai.Format("2006-01-02 15:04:05"),
+			WaktuMulai:   jadwalPosyandu.WaktuMulai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
+			WaktuSelesai: jadwalPosyandu.WaktuSelesai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
 		}
 	}
 
@@ -103,8 +104,8 @@ func (service *jadwalPosyanduServiceImpl) GetByPosyanduID(posyanduID int) ([]mod
 				Alamat: posyandu.Alamat,
 				Foto:   posyandu.Foto,
 			},
-			WaktuMulai:   jadwalPosyandu.WaktuMulai.Format("2006-01-02 15:04:05"),
-			WaktuSelesai: jadwalPosyandu.WaktuSelesai.Format("2006-01-02 15:04:05"),
+			WaktuMulai:   jadwalPosyandu.WaktuMulai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
+			WaktuSelesai: jadwalPosyandu.WaktuSelesai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
 		}
 	}
 
@@ -134,8 +135,8 @@ func (service *jadwalPosyanduServiceImpl) GetByID(id int) (model.JadwalPosyanduR
 			Alamat: posyandu.Alamat,
 			Foto:   posyandu.Foto,
 		},
-		WaktuMulai:   jadwalPosyandu.WaktuMulai.Format("2006-01-02 15:04:05"),
-		WaktuSelesai: jadwalPosyandu.WaktuSelesai.Format("2006-01-02 15:04:05"),
+		WaktuMulai:   jadwalPosyandu.WaktuMulai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
+		WaktuSelesai: jadwalPosyandu.WaktuSelesai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
 	}
 
 	return response, nil
@@ -180,8 +181,8 @@ func (service *jadwalPosyanduServiceImpl) Update(id int, request *model.JadwalPo
 			Alamat: posyandu.Alamat,
 			Foto:   posyandu.Foto,
 		},
-		WaktuMulai:   jadwalPosyandu.WaktuMulai.Format("2006-01-02 15:04:05"),
-		WaktuSelesai: jadwalPosyandu.WaktuSelesai.Format("2006-01-02 15:04:05"),
+		WaktuMulai:   jadwalPosyandu.WaktuMulai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
+		WaktuSelesai: jadwalPosyandu.WaktuSelesai.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
 	}
 
 	return response, nil

--- a/module/pemeriksaan/repository/pemeriksaan_repository.go
+++ b/module/pemeriksaan/repository/pemeriksaan_repository.go
@@ -6,6 +6,7 @@ type PemeriksaanRepository interface {
 	Insert(pemeriksaan *entity.Pemeriksaan) error
 	FindAll() ([]entity.Pemeriksaan, error)
 	FindAllByRemajaID(id int) ([]entity.Pemeriksaan, error)
+	FindAllByPosyanduID(id int) ([]entity.Pemeriksaan, error)
 	FindByID(id int) (entity.Pemeriksaan, error)
 	FindLastByRemajaID(id int) (entity.Pemeriksaan, error)
 	Save(pemeriksaan *entity.Pemeriksaan) error

--- a/module/pemeriksaan/repository/pemeriksaan_repository_impl.go
+++ b/module/pemeriksaan/repository/pemeriksaan_repository_impl.go
@@ -27,6 +27,13 @@ func (repository *pemeriksaanRepositoryImpl) FindAllByRemajaID(id int) ([]entity
 	return pemeriksaan, err
 }
 
+func (repository *pemeriksaanRepositoryImpl) FindAllByPosyanduID(id int) ([]entity.Pemeriksaan, error) {
+	var pemeriksaan []entity.Pemeriksaan
+	err := repository.DB.Find(&pemeriksaan, "posyandu_id = ?", id).Error
+
+	return pemeriksaan, err
+}
+
 func (repository *pemeriksaanRepositoryImpl) FindByID(id int) (entity.Pemeriksaan, error) {
 	var pemeriksaan entity.Pemeriksaan
 	err := repository.DB.Take(&pemeriksaan, id).Error

--- a/module/pemeriksaan/service/pemeriksaan_service_impl.go
+++ b/module/pemeriksaan/service/pemeriksaan_service_impl.go
@@ -9,6 +9,7 @@ import (
 	posyanduRepository "github.com/itsLeonB/posyandu-api/module/posyandu/repository"
 	remajaRepository "github.com/itsLeonB/posyandu-api/module/remaja/repository"
 	userRepository "github.com/itsLeonB/posyandu-api/module/user/repository"
+	"time"
 )
 
 type pemeriksaanServiceImpl struct {
@@ -172,7 +173,7 @@ func (service *pemeriksaanServiceImpl) GetAll() ([]model.PemeriksaanResponse, er
 			TingkatGlukosa:  pemeriksaan.TingkatGlukosa,
 			KadarHemoglobin: pemeriksaan.KadarHemoglobin,
 			PemberianFe:     pemeriksaan.PemberianFe,
-			WaktuPengukuran: pemeriksaan.WaktuPengukuran.Format("2006-01-02 15:04:05"),
+			WaktuPengukuran: pemeriksaan.WaktuPengukuran.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
 			KondisiUmum:     pemeriksaan.KondisiUmum,
 		}
 	}
@@ -250,7 +251,7 @@ func (service *pemeriksaanServiceImpl) GetAllByRemajaID(id int) ([]model.Pemerik
 			TingkatGlukosa:  pemeriksaan.TingkatGlukosa,
 			KadarHemoglobin: pemeriksaan.KadarHemoglobin,
 			PemberianFe:     pemeriksaan.PemberianFe,
-			WaktuPengukuran: pemeriksaan.WaktuPengukuran.Format("2006-01-02 15:04:05"),
+			WaktuPengukuran: pemeriksaan.WaktuPengukuran.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
 			KondisiUmum:     pemeriksaan.KondisiUmum,
 		}
 	}
@@ -323,7 +324,7 @@ func (service *pemeriksaanServiceImpl) GetByID(id int) (model.PemeriksaanRespons
 		TingkatGlukosa:  pemeriksaan.TingkatGlukosa,
 		KadarHemoglobin: pemeriksaan.KadarHemoglobin,
 		PemberianFe:     pemeriksaan.PemberianFe,
-		WaktuPengukuran: pemeriksaan.WaktuPengukuran.Format("2006-01-02 15:04:05"),
+		WaktuPengukuran: pemeriksaan.WaktuPengukuran.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
 		KondisiUmum:     pemeriksaan.KondisiUmum,
 	}
 
@@ -419,7 +420,7 @@ func (service *pemeriksaanServiceImpl) Update(id int, request *model.Pemeriksaan
 		TingkatGlukosa:  pemeriksaan.TingkatGlukosa,
 		KadarHemoglobin: pemeriksaan.KadarHemoglobin,
 		PemberianFe:     pemeriksaan.PemberianFe,
-		WaktuPengukuran: pemeriksaan.WaktuPengukuran.Format("2006-01-02 15:04:05"),
+		WaktuPengukuran: pemeriksaan.WaktuPengukuran.In(time.FixedZone("WIB", 7*3600)).Format("2006-01-02 15:04:05"),
 		KondisiUmum:     pemeriksaan.KondisiUmum,
 	}
 


### PR DESCRIPTION
### Fix

Resolve #33 

```json
{
    "code": 200,
    "status": "OK",
    "data": [
        {
            "id": 1,
            "posyandu": {
                "id": 1,
                "nama": "Posyandu ITS",
                "alamat": "Kampus ITS",
                "foto": "/storage/image/posyandu.png"
            },
            "waktu_mulai": "2024-01-29 20:00:00",
            "waktu_selesai": "2024-01-29 21:00:00"
        }
    ]
}
```

### Reason

Time is stored in `UTC`, due to using `DATETIME` data type instead of `TIMESTAMP`, therefore it needs to be formatted back into the correct timezone `WIB`/`Asia/Jakarta`

Format time with correct timezone
```go
In(time.FixedZone("WIB", 7*3600))
```