### PR TITLE
fix: resolve conflict user endpoint path

### DIFF
--- a/core/middleware/authorization.go
+++ b/core/middleware/authorization.go
@@ -33,6 +33,33 @@ func AuthorizeUser() func(*fiber.Ctx) error {
 	}
 }
 
+func AuthorizeAdminOrBidan() func(*fiber.Ctx) error {
+	return func(c *fiber.Ctx) error {
+		id, err := c.ParamsInt("id")
+		if err != nil {
+			panic(exception.BadRequestError{
+				Message: "Invalid parameter",
+			})
+		}
+
+		claims := c.Locals("user").(*jwt.Token).Claims.(jwt.MapClaims)
+		role := claims["role"].(string)
+		user := int(claims["id"].(float64))
+
+		if role == "admin" || role == "bidan" {
+			return c.Next()
+		}
+
+		if user == id {
+			return c.Next()
+		} else {
+			panic(exception.UnauthorizedError{
+				Message: "Unauthorized access!",
+			})
+		}
+	}
+}
+
 func AuthorizeRole() func(*fiber.Ctx) error {
 	return func(c *fiber.Ctx) error {
 		role := c.Params("role")

--- a/module/user/controller/user_controller.go
+++ b/module/user/controller/user_controller.go
@@ -5,7 +5,6 @@ import "github.com/gofiber/fiber/v2"
 type UserController interface {
 	Route(app *fiber.App)
 	Login(ctx *fiber.Ctx) error
-	ForgetPassword(ctx *fiber.Ctx) error
 	Register(ctx *fiber.Ctx) error
 	GetAll(ctx *fiber.Ctx) error
 	GetByRole(ctx *fiber.Ctx) error

--- a/module/user/controller/user_controller_impl.go
+++ b/module/user/controller/user_controller_impl.go
@@ -16,18 +16,14 @@ type userControllerImpl struct {
 func (controller *userControllerImpl) Route(app *fiber.App) {
 	auth := app.Group("/v1/auth")
 	auth.Post("/login", controller.Login)
-	auth.Post("/forget-password", controller.ForgetPassword)
 
 	user := app.Group("/v1/user", middleware.Authenticate("public"))
-
-	user.Get("/role/:role", middleware.AuthorizeRole(), controller.GetByRole)
-	user.Put("/:id", middleware.AuthorizeUser(), controller.Update)
-	user.Put("/:id/auth", middleware.AuthorizeUser(), controller.UpdateAuth)
-	user.Get("/:id", middleware.AuthorizeUser(), controller.GetByID)
-
 	user.Post("/register", middleware.Authenticate("bidan"), controller.Register)
 	user.Get("/", middleware.Authenticate("bidan"), controller.GetAll)
-	user.Get("/:id", middleware.Authenticate("bidan"), controller.GetByID)
+	user.Get("/role/:role", middleware.AuthorizeRole(), controller.GetByRole)
+	user.Get("/:id", middleware.AuthorizeAdminOrBidan(), controller.GetByID)
+	user.Put("/:id", middleware.AuthorizeAdminOrBidan(), controller.Update)
+	user.Put("/:id/auth", middleware.AuthorizeUser(), controller.UpdateAuth)
 	user.Delete("/:id", middleware.Authenticate("bidan"), controller.Delete)
 }
 
@@ -45,11 +41,6 @@ func (controller *userControllerImpl) Login(ctx *fiber.Ctx) error {
 		Status: "OK",
 		Data:   response,
 	})
-}
-
-func (controller *userControllerImpl) ForgetPassword(ctx *fiber.Ctx) error {
-	//TODO implement me
-	panic("implement me")
 }
 
 func (controller *userControllerImpl) Register(ctx *fiber.Ctx) error {

--- a/module/user/service/user_service_impl.go
+++ b/module/user/service/user_service_impl.go
@@ -55,6 +55,12 @@ func (service *userServiceImpl) Register(request *model.UserRegisterRequest) (mo
 		})
 	}
 
+	if request.Role == "admin" {
+		panic(exception.ForbiddenError{
+			Message: "Forbidden to register admin",
+		})
+	}
+
 	encrypted, err := helper.EncryptPassword(request.Password)
 	exception.PanicIfNeeded(err)
 


### PR DESCRIPTION
### Fix

Resolve #35 

```json
{
    "code": 200,
    "status": "OK",
    "data": {
        <hidden>
    }
}
```

### Reason 

Conflict user endpoint path at `/v1/user/:id`, endpoint initially had 2 separate handlers

```go
user.Get("/:id", middleware.AuthorizeUser(), controller.GetByID)
```

```go
user.Get("/:id", middleware.Authenticate("bidan"), controller.GetByID)
```

It was separated  to only allow `GetByID` for the corresponding user, but `Admin` and `Bidan` should not be restricted to it

Therefore, a new authorization middleware is made
```go
func AuthorizeAdminOrBidan() func(*fiber.Ctx) error {
	return func(c *fiber.Ctx) error {
		id, err := c.ParamsInt("id")
		if err != nil {
			panic(exception.BadRequestError{
				Message: "Invalid parameter",
			})
		}

		claims := c.Locals("user").(*jwt.Token).Claims.(jwt.MapClaims)
		role := claims["role"].(string)
		user := int(claims["id"].(float64))

		if role == "admin" || role == "bidan" {
			return c.Next()
		}

		if user == id {
			return c.Next()
		} else {
			panic(exception.UnauthorizedError{
				Message: "Unauthorized access!",
			})
		}
	}
}
```