### PR TITLE
fix: get remaja by posyandu

### DIFF
--- a/module/remaja/controller/remaja_controller_impl.go
+++ b/module/remaja/controller/remaja_controller_impl.go
@@ -17,7 +17,6 @@ func (controller *remajaControllerImpl) Route(app *fiber.App) {
 	bidan := app.Group("/v1/remaja", middleware.Authenticate("bidan"))
 	bidan.Post("/", controller.Create)
 	bidan.Get("/", controller.GetAll)
-	bidan.Get("/posyandu/:id", controller.GetByPosyanduID)
 	bidan.Get("/:id", controller.GetByID)
 	bidan.Put("/:id", controller.UpdateKader)
 	bidan.Delete("/:id", controller.Delete)
@@ -27,6 +26,9 @@ func (controller *remajaControllerImpl) Route(app *fiber.App) {
 	kader.Get("/", controller.GetAll)
 	kader.Get("/:id", controller.GetByID)
 	kader.Put("/:id", controller.Update)
+
+	remaja := app.Group("/v1/remaja", middleware.Authenticate("public"))
+	remaja.Get("/posyandu/:id", controller.GetByPosyanduID)
 }
 
 func (controller *remajaControllerImpl) Create(ctx *fiber.Ctx) error {


### PR DESCRIPTION
### Fix

Resolve #49 
```json
{
    "code": 200,
    "status": "OK",
    "data": [
        <hidden>
    ]
}
```

### Reason

Initially only allows `bidan` to access, now opened for `public` after #47 request
```go
remaja := app.Group("/v1/remaja", middleware.Authenticate("public"))
remaja.Get("/posyandu/:id", controller.GetByPosyanduID)
```

Also, there is an update on `kader` endpoint for remaja to avoid endpoint conflicts, it now goes under `/v1/kader/remaja`